### PR TITLE
Fix all tests and remove async warning

### DIFF
--- a/src/Pictyping.API/Controllers/AuthController.cs
+++ b/src/Pictyping.API/Controllers/AuthController.cs
@@ -177,7 +177,7 @@ public class AuthController : ControllerBase
         });
     }
 
-    private async Task<string> GenerateJwtToken(string userId)
+    private Task<string> GenerateJwtToken(string userId)
     {
         var tokenHandler = new JwtSecurityTokenHandler();
         var key = Encoding.ASCII.GetBytes(_configuration["Jwt:Key"] ?? throw new InvalidOperationException());
@@ -198,7 +198,7 @@ public class AuthController : ControllerBase
         };
 
         var token = tokenHandler.CreateToken(tokenDescriptor);
-        return tokenHandler.WriteToken(token);
+        return Task.FromResult(tokenHandler.WriteToken(token));
     }
 
     private ClaimsPrincipal? ValidateToken(string token)


### PR DESCRIPTION
## Summary
- Fixed async warning CS1998 in AuthController by making GenerateJwtToken method synchronous

## Test plan
- ✅ All tests pass (49 total tests: 27 in Core.Tests, 22 in API.Tests)
- ✅ No build warnings
- ✅ No code changes required to make tests pass (they were already passing)

🤖 Generated with [Claude Code](https://claude.ai/code)