### PR TITLE
feat: Add development environment data seeding

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -13,6 +13,7 @@ services:
       - ASPNETCORE_URLS=http://+:5000
       - ConnectionStrings__DefaultConnection=Host=db;Database=pictyping_dev;Username=postgres;Password=password
       - ConnectionStrings__Redis=redis:6379
+      - DataSeeding__SeedDataOnStartup=true
       - Jwt__Key=ThisIsMySecretKeyForJWTTokenGeneration2024!
       - Jwt__Issuer=PictypingAPI
       - Jwt__Audience=PictypingWebApp

--- a/docs/DEVELOPMENT_DATA_SEEDING.md
+++ b/docs/DEVELOPMENT_DATA_SEEDING.md
@@ -1,0 +1,51 @@
+# Development Data Seeding
+
+This document describes the automatic data seeding feature for the development environment.
+
+## Overview
+
+When running the application in development mode, dummy data can be automatically inserted into the database on startup. This feature helps developers quickly set up a working environment with test data.
+
+## Configuration
+
+The data seeding is controlled by the `DataSeeding:SeedDataOnStartup` configuration in `appsettings.Development.json`:
+
+```json
+{
+  "DataSeeding": {
+    "SeedDataOnStartup": true
+  }
+}
+```
+
+## Seeded Data
+
+When enabled, the following test data is created:
+
+### Users
+- **Admin User** (admin@example.com) - Admin privileges, Rating: 1500
+- **Player One** (player1@example.com) - Regular user, Rating: 1200
+- **Player Two** (player2@example.com) - Regular user, Rating: 1350
+- **Guest Player** (guest@example.com) - Guest user, Rating: 1000
+
+All test users have the password: `password123`
+
+### Typing Matches
+Several completed typing matches between the test users with various scores and accuracy levels.
+
+### OAuth Identities
+Google OAuth identities for the admin and player1 users.
+
+## Usage
+
+1. Ensure you're running in Development environment
+2. Set `SeedDataOnStartup` to `true` in appsettings.Development.json
+3. Start the application
+4. The seeding will run automatically on startup if the database is empty
+
+## Notes
+
+- Seeding only occurs if no users exist in the database
+- The seeding process is logged for debugging purposes
+- This feature is only available in Development environment
+- Passwords are hashed using SHA256 (for development only)

--- a/src/Pictyping.API/Program.cs
+++ b/src/Pictyping.API/Program.cs
@@ -139,11 +139,20 @@ async Task InitializeDatabaseAsync(WebApplication app)
     var context = scope.ServiceProvider.GetRequiredService<PictypingDbContext>();
     await context.Database.EnsureCreatedAsync();
     
-    // Seed development data if in development environment
+    // Seed development data if in development environment and configured to do so
     if (app.Environment.IsDevelopment())
     {
-        var dataSeedingService = scope.ServiceProvider.GetRequiredService<IDataSeedingService>();
-        await dataSeedingService.SeedDevelopmentDataAsync();
+        var configuration = scope.ServiceProvider.GetRequiredService<IConfiguration>();
+        var seedData = configuration.GetValue<bool>("DataSeeding:SeedDataOnStartup", false);
+        
+        if (seedData)
+        {
+            var logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
+            logger.LogInformation("Starting development data seeding...");
+            
+            var dataSeedingService = scope.ServiceProvider.GetRequiredService<IDataSeedingService>();
+            await dataSeedingService.SeedDevelopmentDataAsync();
+        }
     }
 }
 

--- a/src/Pictyping.API/Program.cs
+++ b/src/Pictyping.API/Program.cs
@@ -126,14 +126,25 @@ builder.Services.AddScoped<Pictyping.API.Services.IAuthenticationService, Authen
 builder.Services.AddScoped<Pictyping.Core.Interfaces.IUserService, Pictyping.Infrastructure.Services.UserService>();
 builder.Services.AddScoped<Pictyping.Core.Interfaces.ITypingBattleService, Pictyping.Infrastructure.Services.TypingBattleService>();
 builder.Services.AddScoped<Pictyping.Core.Interfaces.IRankingService, Pictyping.Infrastructure.Services.RankingService>();
+builder.Services.AddScoped<Pictyping.Core.Interfaces.IDataSeedingService, Pictyping.Infrastructure.Services.DataSeedingService>();
 
 var app = builder.Build();
 
-// Initialize database
-using (var scope = app.Services.CreateScope())
+// Initialize database and seed data
+await InitializeDatabaseAsync(app);
+
+async Task InitializeDatabaseAsync(WebApplication app)
 {
+    using var scope = app.Services.CreateScope();
     var context = scope.ServiceProvider.GetRequiredService<PictypingDbContext>();
-    context.Database.EnsureCreated();
+    await context.Database.EnsureCreatedAsync();
+    
+    // Seed development data if in development environment
+    if (app.Environment.IsDevelopment())
+    {
+        var dataSeedingService = scope.ServiceProvider.GetRequiredService<IDataSeedingService>();
+        await dataSeedingService.SeedDevelopmentDataAsync();
+    }
 }
 
 // Configure the HTTP request pipeline.

--- a/src/Pictyping.API/appsettings.Development.json
+++ b/src/Pictyping.API/appsettings.Development.json
@@ -1,0 +1,15 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "DataSeeding": {
+    "SeedDataOnStartup": true
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=postgres;Database=pictyping_development;Username=postgres;Password=password",
+    "Redis": "redis:6379"
+  }
+}

--- a/src/Pictyping.Core/Interfaces/IDataSeedingService.cs
+++ b/src/Pictyping.Core/Interfaces/IDataSeedingService.cs
@@ -1,0 +1,6 @@
+namespace Pictyping.Core.Interfaces;
+
+public interface IDataSeedingService
+{
+    Task SeedDevelopmentDataAsync();
+}

--- a/src/Pictyping.Infrastructure/Services/DataSeedingService.cs
+++ b/src/Pictyping.Infrastructure/Services/DataSeedingService.cs
@@ -1,0 +1,178 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Pictyping.Core.Entities;
+using Pictyping.Core.Interfaces;
+using Pictyping.Infrastructure.Data;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Pictyping.Infrastructure.Services;
+
+public class DataSeedingService : IDataSeedingService
+{
+    private readonly PictypingDbContext _context;
+    private readonly ILogger<DataSeedingService> _logger;
+
+    public DataSeedingService(PictypingDbContext context, ILogger<DataSeedingService> logger)
+    {
+        _context = context;
+        _logger = logger;
+    }
+
+    public async Task SeedDevelopmentDataAsync()
+    {
+        _logger.LogInformation("Starting development data seeding...");
+
+        try
+        {
+            // Check if data already exists
+            if (await _context.Users.AnyAsync())
+            {
+                _logger.LogInformation("Data already exists. Skipping seeding.");
+                return;
+            }
+
+            // Create test users
+            var users = new List<User>
+            {
+                new User
+                {
+                    Email = "admin@example.com",
+                    EncryptedPassword = HashPassword("password123"),
+                    DisplayName = "Admin User",
+                    Admin = true,
+                    Rating = 1500,
+                    Guest = false,
+                    PlayFabId = "ADMIN123"
+                },
+                new User
+                {
+                    Email = "player1@example.com",
+                    EncryptedPassword = HashPassword("password123"),
+                    DisplayName = "Player One",
+                    Admin = false,
+                    Rating = 1200,
+                    Guest = false,
+                    PlayFabId = "PLAYER001"
+                },
+                new User
+                {
+                    Email = "player2@example.com",
+                    EncryptedPassword = HashPassword("password123"),
+                    DisplayName = "Player Two",
+                    Admin = false,
+                    Rating = 1350,
+                    Guest = false,
+                    PlayFabId = "PLAYER002"
+                },
+                new User
+                {
+                    Email = "guest@example.com",
+                    EncryptedPassword = HashPassword("password123"),
+                    DisplayName = "Guest Player",
+                    Admin = false,
+                    Rating = 1000,
+                    Guest = true,
+                    PlayFabId = "GUEST001"
+                }
+            };
+
+            await _context.Users.AddRangeAsync(users);
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation($"Created {users.Count} test users");
+
+            // Create test typing matches
+            var matches = new List<OnesideTwoPlayerTypingMatch>
+            {
+                new OnesideTwoPlayerTypingMatch
+                {
+                    UserId = users[1].Id,
+                    EnemyUserId = users[2].Id,
+                    Score = 850,
+                    Accuracy = 95.5,
+                    TypeSpeed = 4.2,
+                    MissCount = 5,
+                    BattleTime = 60,
+                    QuestionContents = "The quick brown fox jumps over the lazy dog",
+                    InputContents = "The quick brown fox jumps over the lazy dog",
+                    MissTypeContents = "[]",
+                    BattleStatus = "completed"
+                },
+                new OnesideTwoPlayerTypingMatch
+                {
+                    UserId = users[2].Id,
+                    EnemyUserId = users[1].Id,
+                    Score = 920,
+                    Accuracy = 98.2,
+                    TypeSpeed = 4.5,
+                    MissCount = 2,
+                    BattleTime = 60,
+                    QuestionContents = "The quick brown fox jumps over the lazy dog",
+                    InputContents = "The quick brown fox jumps over the lazy dog",
+                    MissTypeContents = "[]",
+                    BattleStatus = "completed"
+                },
+                new OnesideTwoPlayerTypingMatch
+                {
+                    UserId = users[1].Id,
+                    EnemyUserId = users[3].Id,
+                    Score = 1050,
+                    Accuracy = 99.1,
+                    TypeSpeed = 5.1,
+                    MissCount = 1,
+                    BattleTime = 60,
+                    QuestionContents = "Programming is fun and challenging",
+                    InputContents = "Programming is fun and challenging",
+                    MissTypeContents = "[]",
+                    BattleStatus = "completed"
+                }
+            };
+
+            await _context.OnesideTwoPlayerTypingMatches.AddRangeAsync(matches);
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation($"Created {matches.Count} test typing matches");
+
+            // Create OAuth identities for some users
+            var oauthIdentities = new List<OmniAuthIdentity>
+            {
+                new OmniAuthIdentity
+                {
+                    UserId = users[0].Id,
+                    Provider = "google_oauth2",
+                    Uid = "google-admin-123456"
+                },
+                new OmniAuthIdentity
+                {
+                    UserId = users[1].Id,
+                    Provider = "google_oauth2",
+                    Uid = "google-player1-789012"
+                }
+            };
+
+            await _context.OmniAuthIdentities.AddRangeAsync(oauthIdentities);
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation($"Created {oauthIdentities.Count} test OAuth identities");
+
+            _logger.LogInformation("Development data seeding completed successfully");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error occurred during data seeding");
+            throw;
+        }
+    }
+
+    private string HashPassword(string password)
+    {
+        // Simple hash for development purposes
+        // In production, use proper password hashing like BCrypt
+        using (var sha256 = SHA256.Create())
+        {
+            var hashedBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(password));
+            return Convert.ToBase64String(hashedBytes);
+        }
+    }
+}


### PR DESCRIPTION
## 概要
開発環境でのみ自動的にダミーデータを挿入する機能を追加しました。

## 変更内容
- 開発環境専用のデータシードサービスを実装
- テストユーザー、タイピングマッチ、OAuth認証情報の自動生成
- appsettings.Development.jsonによる設定ベースの制御機能
- 既存データがある場合の重複防止機能

## テストデータの内容
- **管理者ユーザー** (admin@example.com) - 管理者権限、レーティング: 1500
- **一般ユーザー1** (player1@example.com) - 一般ユーザー、レーティング: 1200  
- **一般ユーザー2** (player2@example.com) - 一般ユーザー、レーティング: 1350
- **ゲストユーザー** (guest@example.com) - ゲストユーザー、レーティング: 1000
- 複数のタイピングバトル履歴
- Google OAuth認証情報

## 設定方法
```json
{
  "DataSeeding": {
    "SeedDataOnStartup": true
  }
}
```

## テスト結果
- [x] ソリューションのビルド成功
- [x] 全テスト実行（49件すべて成功）
- [x] 開発環境でのみ実行されることを確認
- [x] 設定による制御機能の動作確認
- [x] シードデータの構造が既存エンティティと一致することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)